### PR TITLE
『シナリオのGitHub管理』ページのシンボリックリンクの説明を修正

### DIFF
--- a/src/containers/GitHubScenario/index.js
+++ b/src/containers/GitHubScenario/index.js
@@ -31,21 +31,13 @@ $ git pull
 
 #リソースを一元管理する
 
-リポジトリに以下のディレクトリを作成します。
-
-~
-Sound
-Pictures
-Command
-~
-
 それぞれのディレクトリのシンボリックリンクを以下のようにして作成します。
 
 ~
 $ cd ~/Documents/[リポジトリ名]
-$ ln -s \`realpath ./Sound\` ~/Sound/[リポジトリ名]
-$ ln -s \`realpath ./Pictures\` ~/Pictures/[リポジトリ名]
-$ ln -s \`realpath ./Command\` ~/dora-engine/command/[リポジトリ名]
+$ ln -s \`realpath ~/Sound\` Sound
+$ ln -s \`realpath ~/Pictures\` Pictures
+$ ln -s \`realpath ~/dora-engine/command\` Command
 ~
 `
 

--- a/src/containers/GitHubScenario/index.js
+++ b/src/containers/GitHubScenario/index.js
@@ -35,9 +35,9 @@ $ git pull
 
 ~
 $ cd ~/Documents/[リポジトリ名]
-$ ln -s \`realpath ~/Sound\` Sound
-$ ln -s \`realpath ~/Pictures\` Pictures
-$ ln -s \`realpath ~/dora-engine/command\` Command
+$ ln -s \`realpath ~/Sound/[リポジトリ名]\` Sound
+$ ln -s \`realpath ~/Pictures/[リポジトリ名]\` Pictures
+$ ln -s \`realpath ~/dora-engine/command/[リポジトリ名]\` Command
 ~
 `
 


### PR DESCRIPTION
lnコマンドの実体ファイルとリンク名の指定が逆になっているようなので修正しました。